### PR TITLE
docs: fix first-time reader interruption points in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Engineering Framework
+# AI Engineering Framework (AIEF)
 
 > A project-level context layer that makes AI coding assistants truly understand your codebase.
 
@@ -14,9 +14,11 @@ Get your project AI-ready in 5 minutes.
 
 ## What Is This?
 
-AI coding assistants (Cursor, Copilot, Claude Code, etc.) start every session with zero knowledge of your project's business rules, architecture decisions, and hard-won lessons.
+AI coding assistants (Cursor, Copilot, Claude Code, etc.) can read files, but they still miss stable project context: business boundaries, architecture decisions, and hard-won team lessons.
 
-**AI Engineering Framework** gives your project a structured entry point - an `AGENTS.md` file plus a `context/` knowledge base - so AI can automatically load what it needs. No vendor lock-in. Works with any AI tool that supports the [AGENTS.md standard](https://github.com/anthropics/claude-code/blob/main/AGENTS.md).
+**AIEF** gives your project a structured entry point - an `AGENTS.md` file plus a `context/` knowledge base - so AI can load the right context consistently.
+
+`AGENTS.md` is a cross-tool convention used by mainstream AI coding tools. No vendor lock-in.
 
 AIEF focuses on stable collaboration context, not model cleverness.
 
@@ -26,7 +28,27 @@ Why teams adopt it:
 - Shared project rules across people and tools
 - Incremental adoption (start small, expand when needed)
 
+## The Problem
+
+Most teams using AI in daily development hit the same issues:
+
+- **Rules are scattered** - prompts and conventions live in personal habits
+- **Context is repeatedly re-explained** - each task restarts from partial understanding
+- **Knowledge does not compound** - decisions and pitfalls are not captured as team assets
+- **Onboarding is fragile** - new members cannot reuse prior AI collaboration patterns
+
+This framework solves these with one stable, project-level entry point.
+
 ## 5-Minute Quick Start
+
+Choose one path. Both are non-invasive and do not change your business code structure.
+
+Level cheat sheet for retrofit:
+
+- `L0`: create the minimum entry files only
+- `L0+`: `L0` plus an auto-generated repo snapshot
+
+Package note: `@tongsh6/aief-init` is the short alias package. Canonical package: `@tongsh6/ai-engineering-framework-init`.
 
 ### Option A: New Project
 
@@ -35,27 +57,39 @@ Why teams adopt it:
 npx --yes @tongsh6/aief-init@latest new
 ```
 
-Then open the generated `AGENTS.md` and fill in:
+Step 2 - Open the generated `AGENTS.md` template and fill in:
 
 1. One-line project description
 2. Key constraints (e.g., directory boundaries, critical rules)
 3. Common commands (`build` / `test` / `run`)
 
-Done. Start coding with your AI assistant.
+Step 3 - Verify in 30 seconds:
+
+- `AGENTS.md` exists in project root
+- `context/INDEX.md` exists
+
+Done. Start coding with your AI assistant from this fixed entry point.
 
 ### Option B: Existing Project (Retrofit)
 
 ```bash
 # Step 1 - Run this in your project root
+# L0+ keeps code untouched and also generates a repo snapshot
 npx --yes @tongsh6/aief-init@latest retrofit --level L0+
 ```
 
-Then check:
+Step 2 - Check generated files:
 
 1. `AGENTS.md` - fill in your project info
-2. `context/tech/REPO_SNAPSHOT.md` - check the auto-generated repo snapshot
+2. `context/tech/REPO_SNAPSHOT.md` - review auto-detected stack, directory layout, and CI clues
 
-Done. Start coding with your AI assistant.
+Step 3 - Verify in 30 seconds:
+
+- `AGENTS.md` exists in project root
+- `context/INDEX.md` exists
+- `context/tech/REPO_SNAPSHOT.md` exists (for `L0+`)
+
+Done. Start coding with your AI assistant from this fixed entry point.
 
 ### Before / After
 
@@ -72,19 +106,9 @@ your-project/                    your-project/
                                  └── ...
 ```
 
-A few files added. AI now understands your project.
+A few files added. AI now has a stable, reusable way to read your project context.
 
-> **Manual install** (offline / intranet): `git clone` this repo, then copy `AGENTS.md` and `context/` into your project. See [init/](init/) for details.
-
-## The Problem
-
-Every time you start a new AI coding session:
-
-- **Context is lost** - AI cannot see your past decisions, business boundaries, or coding standards
-- **Knowledge does not compound** - you explain the same things over and over, marginal cost stays flat
-- **Tools are fragmented** - each AI tool has its own config format
-
-This framework solves all three with a single, tool-agnostic entry point.
+> **Manual install** (offline / intranet): `git clone` the AIEF repository, then copy `AGENTS.md` and `context/` into your project. See [init/](init/) for details.
 
 ## Core Concept
 
@@ -98,7 +122,7 @@ These are implemented with:
 
 - `AGENTS.md` as the project-level AI entry point
 - `context/` as long-term context storage
-- `experience/` as the compounding mechanism
+- `context/experience/` as the compounding mechanism
 - `workflow/` as an optional collaboration enhancer
 
 ## Repository Structure and Read Order
@@ -113,7 +137,7 @@ You do not need every file on day one. Recommended read/use order:
 6. `workflow/` (optional)
 7. `.ai-adapters/` (tool-specific, optional)
 
-Structure overview:
+Condensed structure overview:
 
 ```
 your-project/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-# AI Engineering Framework
+# AI Engineering Framework (AIEF)
 
 > 项目级上下文层，让 AI 编码助手真正理解你的代码库。
 
@@ -14,9 +14,11 @@
 
 ## 这是什么？
 
-AI 编码助手（Cursor、Copilot、Claude Code 等）每次开启会话时，对你的业务规则、架构决策和踩过的坑一无所知。
+AI 编码助手（Cursor、Copilot、Claude Code 等）可以读取代码文件，但通常缺少稳定的项目上下文：业务边界、架构决策和团队踩坑经验。
 
-**AI Engineering Framework** 为你的项目提供一个结构化入口 - 一个 `AGENTS.md` 文件加一个 `context/` 知识库 - 让 AI 能自动加载所需的上下文。不绑定任何工具，支持所有兼容 [AGENTS.md 标准](https://github.com/anthropics/claude-code/blob/main/AGENTS.md) 的 AI 工具。
+**AIEF** 为你的项目提供一个结构化入口 - 一个 `AGENTS.md` 文件加一个 `context/` 知识库 - 让 AI 稳定、持续地加载正确上下文。
+
+`AGENTS.md` 是被主流 AI 编码工具支持的跨工具约定，不绑定单一厂商。
 
 AIEF 关注的是稳定协作上下文，而不是让模型“更聪明”。
 
@@ -26,7 +28,27 @@ AIEF 关注的是稳定协作上下文，而不是让模型“更聪明”。
 - 项目规则在团队和工具之间统一
 - 可渐进接入（先最小可用，再按需扩展）
 
+## 它解决什么问题？
+
+在多数团队的日常 AI 开发里，常见问题是：
+
+- **规则分散** - prompt 与约定散落在个人习惯里
+- **上下文反复解释** - 每次任务都从部分理解重新开始
+- **知识不复利** - 决策与踩坑无法沉淀为团队资产
+- **新人接入脆弱** - 新成员无法复用既有 AI 协作模式
+
+本框架通过一个稳定的项目级入口解决这些问题。
+
 ## 5 分钟快速开始
+
+二选一即可。两条路径都不改你的业务代码结构。
+
+Retrofit 等级速记：
+
+- `L0`：仅生成最小入口文件
+- `L0+`：`L0` + 自动生成仓库快照
+
+包名说明：`@tongsh6/aief-init` 是短命令别名包；canonical 包名是 `@tongsh6/ai-engineering-framework-init`。
 
 ### 场景 A：新项目
 
@@ -35,27 +57,39 @@ AIEF 关注的是稳定协作上下文，而不是让模型“更聪明”。
 npx --yes @tongsh6/aief-init@latest new
 ```
 
-然后打开生成的 `AGENTS.md`，填写：
+第 2 步 - 打开生成的 `AGENTS.md` 模板，填写：
 
 1. 项目一句话介绍
 2. 核心约束（如：目录边界、关键规则）
 3. 常用命令（`build` / `test` / `run`）
 
-完成。开始用 AI 助手编码。
+第 3 步 - 30 秒验证：
+
+- 项目根目录存在 `AGENTS.md`
+- 存在 `context/INDEX.md`
+
+完成。开始从这个固定入口发起 AI 协作。
 
 ### 场景 B：已有项目（Retrofit）
 
 ```bash
 # 第 1 步 - 在项目根目录执行
+# L0+ 不改业务代码，同时生成仓库快照
 npx --yes @tongsh6/aief-init@latest retrofit --level L0+
 ```
 
-然后检查：
+第 2 步 - 检查生成文件：
 
 1. `AGENTS.md` - 填入项目信息
-2. `context/tech/REPO_SNAPSHOT.md` - 检查自动生成的仓库快照
+2. `context/tech/REPO_SNAPSHOT.md` - 检查自动识别的技术栈、目录结构与 CI 线索
 
-完成。开始用 AI 助手编码。
+第 3 步 - 30 秒验证：
+
+- 项目根目录存在 `AGENTS.md`
+- 存在 `context/INDEX.md`
+- `L0+` 场景下存在 `context/tech/REPO_SNAPSHOT.md`
+
+完成。开始从这个固定入口发起 AI 协作。
 
 ### Before / After
 
@@ -72,19 +106,9 @@ your-project/                    your-project/
                                  └── ...
 ```
 
-加上少量入口文件后，AI 就能理解你的项目。
+增加少量入口文件后，AI 就有了稳定、可复用的项目读取路径。
 
-> **手动安装**（离线/内网场景）：`git clone` 本仓库，然后将 `AGENTS.md` 和 `context/` 复制到你的项目。详见 [init/](init/)。
-
-## 它解决什么问题？
-
-每次开启新的 AI 编码会话：
-
-- **上下文丢失** - AI 看不到你过去的决策、业务边界和编码规范
-- **知识不复利** - 你反复解释同样的事情，边际成本恒定
-- **工具碎片化** - 每个 AI 工具有不同的配置格式
-
-本框架用一个工具无关的统一入口解决以上三个问题。
+> **手动安装**（离线/内网场景）：`git clone` AIEF 仓库，然后将 `AGENTS.md` 和 `context/` 复制到你的项目。详见 [init/](init/)。
 
 ## 核心概念
 
@@ -98,7 +122,7 @@ AIEF 建立在三个长期存在的工程事实之上：
 
 - `AGENTS.md` 作为项目级 AI 入口
 - `context/` 作为长期上下文承载
-- `experience/` 作为经验复利机制
+- `context/experience/` 作为经验复利机制
 - `workflow/` 作为可选协作增强
 
 ## 仓库结构与阅读顺序
@@ -113,7 +137,7 @@ AIEF 建立在三个长期存在的工程事实之上：
 6. `workflow/`（可选）
 7. `.ai-adapters/`（按工具启用，可选）
 
-目录结构概览：
+精简目录概览：
 
 ```
 your-project/


### PR DESCRIPTION
## Summary
- 修复 README 在陌生用户首次阅读中的关键打断点，降低首屏流失
- 调整信息顺序：前置问题定义，再给 5 分钟接入路径
- 增加 L0/L0+ 就地解释与 30 秒验证步骤，并同步中英文文案

## Why
- 降低首次接入时的理解阻力，让用户更容易完成第一次可用接入
- 提升 README 的可达成性与可信度，避免过度承诺

## Scope
- Updated: `README.md`
- Updated: `README.zh-CN.md`