### PR TITLE
docs: reduce quick-start interruption points

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ Level cheat sheet for retrofit:
 - `L0`: create the minimum entry files only
 - `L0+`: `L0` plus an auto-generated repo snapshot
 
-Package note: `@tongsh6/aief-init` is the short alias package. Canonical package: `@tongsh6/ai-engineering-framework-init`.
-
 ### Option A: New Project
 
 ```bash
@@ -67,6 +65,10 @@ Step 3 - Verify in 30 seconds:
 
 - `AGENTS.md` exists in project root
 - `context/INDEX.md` exists
+
+Optional: Verify behavior in your AI tool:
+
+- Ask: "Summarize project rules from `AGENTS.md`." It should quote or reference the file.
 
 Done. Start coding with your AI assistant from this fixed entry point.
 
@@ -89,6 +91,10 @@ Step 3 - Verify in 30 seconds:
 - `context/INDEX.md` exists
 - `context/tech/REPO_SNAPSHOT.md` exists (for `L0+`)
 
+Optional: Verify behavior in your AI tool:
+
+- Ask: "Summarize project rules from `AGENTS.md`." It should quote or reference the file.
+
 Done. Start coding with your AI assistant from this fixed entry point.
 
 ### Before / After
@@ -102,13 +108,21 @@ your-project/                    your-project/
                                  ├── context/
                                  │   ├── INDEX.md         <- knowledge base nav
                                  │   └── tech/
-                                 │       └── REPO_SNAPSHOT.md  <- auto-generated
+                                 │       └── REPO_SNAPSHOT.md  <- auto-generated (retrofit `L0+` only)
                                  └── ...
 ```
 
 A few files added. AI now has a stable, reusable way to read your project context.
 
 > **Manual install** (offline / intranet): `git clone` the AIEF repository, then copy `AGENTS.md` and `context/` into your project. See [init/](init/) for details.
+
+<details>
+<summary><strong>Package names</strong></summary>
+
+- Short alias package: `@tongsh6/aief-init`
+- Canonical package: `@tongsh6/ai-engineering-framework-init`
+
+</details>
 
 ## Core Concept
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,8 +48,6 @@ Retrofit 等级速记：
 - `L0`：仅生成最小入口文件
 - `L0+`：`L0` + 自动生成仓库快照
 
-包名说明：`@tongsh6/aief-init` 是短命令别名包；canonical 包名是 `@tongsh6/ai-engineering-framework-init`。
-
 ### 场景 A：新项目
 
 ```bash
@@ -67,6 +65,10 @@ npx --yes @tongsh6/aief-init@latest new
 
 - 项目根目录存在 `AGENTS.md`
 - 存在 `context/INDEX.md`
+
+可选：验证工具行为：
+
+- 让你的 AI 工具执行："从 `AGENTS.md` 总结项目约束"，并要求其引用/标注来源文件。
 
 完成。开始从这个固定入口发起 AI 协作。
 
@@ -89,6 +91,10 @@ npx --yes @tongsh6/aief-init@latest retrofit --level L0+
 - 存在 `context/INDEX.md`
 - `L0+` 场景下存在 `context/tech/REPO_SNAPSHOT.md`
 
+可选：验证工具行为：
+
+- 让你的 AI 工具执行："从 `AGENTS.md` 总结项目约束"，并要求其引用/标注来源文件。
+
 完成。开始从这个固定入口发起 AI 协作。
 
 ### Before / After
@@ -102,13 +108,21 @@ your-project/                    your-project/
                                  ├── context/
                                  │   ├── INDEX.md         <- 知识库导航
                                  │   └── tech/
-                                 │       └── REPO_SNAPSHOT.md  <- 自动生成
+                                 │       └── REPO_SNAPSHOT.md  <- 自动生成（仅 retrofit `L0+`）
                                  └── ...
 ```
 
 增加少量入口文件后，AI 就有了稳定、可复用的项目读取路径。
 
 > **手动安装**（离线/内网场景）：`git clone` AIEF 仓库，然后将 `AGENTS.md` 和 `context/` 复制到你的项目。详见 [init/](init/)。
+
+<details>
+<summary><strong>包名说明</strong></summary>
+
+- 短命令别名包：`@tongsh6/aief-init`
+- canonical 包名：`@tongsh6/ai-engineering-framework-init`
+
+</details>
 
 ## 核心概念
 


### PR DESCRIPTION
## Summary
- 在 Quick Start 中增加“工具行为验证”步骤（不止检查文件存在）
- 在 Before/After 标注 `REPO_SNAPSHOT.md` 仅适用于 retrofit `L0+`
- 将包名说明折叠，减少首次上手的注意力分散
- 同步更新 `README.md` 与 `README.zh-CN.md`

## Why
- 陌生用户完成 5 分钟接入后，需要一个可验证的成功判定
- 避免目录示意图对不同路径产生误导

## Scope
- Updated: `README.md`
- Updated: `README.zh-CN.md`