### PR TITLE
feat: 更新初始化脚本和文档以支持 L1/L2 标准规范

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,7 +157,8 @@ AIEF 建立在三个长期存在的工程事实之上：
 4. `context/tech/`
 5. `context/experience/`
 6. `workflow/`（可选）
-7. `.ai-adapters/`（按工具启用，可选）
+7. `docs/standards/`（L1/L2 标准规范，可选）
+8. `.ai-adapters/`（按工具启用，可选）
 
 精简目录概览：
 
@@ -170,6 +171,7 @@ your-project/
 │   ├── tech/                    # 架构、API、开发规范
 │   └── experience/              # 经验沉淀（复利）
 ├── workflow/                    # 多阶段工作流（可选）
+├── docs/standards/              # Skill/Command/Agent 规范与模式（可选）
 └── .ai-adapters/                # 工具特定配置（可选）
 ```
 
@@ -243,8 +245,8 @@ your-project/
 | **L0** | 5 分钟 | `AGENTS.md` + `context/INDEX.md`（可以是空的） |
 | **L0+** | 10 分钟 | + 自动生成的 `REPO_SNAPSHOT.md` |
 | **L1** | 1-2 小时 | + 一页业务文档 + 一页技术文档 |
-| **L2** | 可选 | + 工作流、经验模板、CI 校验 |
-| **L3** | 持续 | + 持续经验复利 |
+| **L2** | 可选 | + 工作流、经验模板、Skill/Command/Agent 标准规范 |
+| **L3** | 持续 | + 持续经验复利、跨切面模式（自动路由/经验管理/上下文加载） |
 
 从 L0 开始。感到需要时再升级。
 
@@ -315,6 +317,7 @@ AIEF 是旁路式规范，不会侵入你的业务代码结构。
 - [AGENTS.md 标准](https://github.com/anthropics/claude-code/blob/main/AGENTS.md) - 工具无关的 AI 指南标准
 - [Context Engineering](https://context.engineering) - 上下文工程方法论
 - [OpenSpec](https://openspec.dev) - 规范驱动开发框架
+- [认知重建：Speckit 用了三个月，我放弃了](https://zhuanlan.zhihu.com/p/1993009461451831150) - 核心思想来源，从工具思维到工程思维的转变历程
 
 ## License
 

--- a/init/MIGRATION_LEVELS.md
+++ b/init/MIGRATION_LEVELS.md
@@ -13,11 +13,13 @@ L1（最小可读性）：
 L2（可选增强）：
 - 引入 workflow/（可选）
 - 引入 experience 模板
+- 引入 Skill/Command/Agent 标准规范（docs/standards/）
 - 可开启校验机制（例如：PR 检查、CI 校验）
 
 L3（持续运行）：
 - 持续沉淀经验
 - 每个重要变更至少记录一条 experience
+- 引入跨切面模式（自动阶段路由、经验管理、上下文加载）
 
 注意：
 - L0 不修改现有代码结构

--- a/packages/ai-engineering-framework-init/bin/aief-init.mjs
+++ b/packages/ai-engineering-framework-init/bin/aief-init.mjs
@@ -314,6 +314,11 @@ function initRetrofit({ level, force, dryRun } = {}) {
   const snapshotPath = repoPath('context/tech/REPO_SNAPSHOT.md')
   const snapshotContent = formatRepoSnapshot(process.cwd())
   writeFile(snapshotPath, snapshotContent, { force, dryRun })
+
+  if (level === 'L1') {
+    // Create docs/standards/ directory structure for L1+ projects
+    ensureDir(repoPath('docs/standards/patterns'), { dryRun })
+  }
 }
 
 function main() {

--- a/packages/ai-engineering-framework-init/package.json
+++ b/packages/ai-engineering-framework-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tongsh6/ai-engineering-framework-init",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Optional bootstrap CLI for AI Engineering Framework (AIEF)",
   "license": "MIT",
   "type": "module",

--- a/packages/ai-engineering-framework-init/templates/minimal/AGENTS.md
+++ b/packages/ai-engineering-framework-init/templates/minimal/AGENTS.md
@@ -17,3 +17,14 @@ Quick Commands:
 
 Context Entry:
 - context/INDEX.md
+
+Knowledge Base:
+
+| Directory | Purpose | When to Load |
+|-----------|---------|-------------|
+| context/business/ | Business knowledge | Understanding requirements, domain models |
+| context/tech/ | Technical docs | Architecture, API, conventions |
+| context/experience/ | Experience library | Avoid repeating mistakes |
+| workflow/ | Workflows | Complex task phase guides (optional) |
+| docs/standards/ | Standards | Skill/Command/Agent specs (L1, optional) |
+| docs/standards/patterns/ | Patterns | Phase routing, experience mgmt, context loading (L2, optional) |

--- a/packages/aief-init/bin/aief-init.mjs
+++ b/packages/aief-init/bin/aief-init.mjs
@@ -316,6 +316,11 @@ function initRetrofit({ level, force, dryRun } = {}) {
   const snapshotPath = repoPath('context/tech/REPO_SNAPSHOT.md')
   const snapshotContent = formatRepoSnapshot(process.cwd())
   writeFile(snapshotPath, snapshotContent, { force, dryRun })
+
+  if (level === 'L1') {
+    // Create docs/standards/ directory structure for L1+ projects
+    ensureDir(repoPath('docs/standards/patterns'), { dryRun })
+  }
 }
 
 function main() {

--- a/packages/aief-init/package.json
+++ b/packages/aief-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tongsh6/aief-init",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Short alias for @tongsh6/ai-engineering-framework-init",
   "license": "MIT",
   "type": "module",

--- a/packages/aief-init/templates/minimal/AGENTS.md
+++ b/packages/aief-init/templates/minimal/AGENTS.md
@@ -17,3 +17,14 @@ Quick Commands:
 
 Context Entry:
 - context/INDEX.md
+
+Knowledge Base:
+
+| Directory | Purpose | When to Load |
+|-----------|---------|-------------|
+| context/business/ | Business knowledge | Understanding requirements, domain models |
+| context/tech/ | Technical docs | Architecture, API, conventions |
+| context/experience/ | Experience library | Avoid repeating mistakes |
+| workflow/ | Workflows | Complex task phase guides (optional) |
+| docs/standards/ | Standards | Skill/Command/Agent specs (L1, optional) |
+| docs/standards/patterns/ | Patterns | Phase routing, experience mgmt, context loading (L2, optional) |

--- a/scripts/aief-init.mjs
+++ b/scripts/aief-init.mjs
@@ -318,6 +318,11 @@ function initRetrofit({ level, force, dryRun } = {}) {
   const snapshotPath = repoPath('context/tech/REPO_SNAPSHOT.md')
   const snapshotContent = formatRepoSnapshot(process.cwd())
   writeFile(snapshotPath, snapshotContent, { force, dryRun })
+
+  if (level === 'L1') {
+    // Create docs/standards/ directory structure for L1+ projects
+    ensureDir(repoPath('docs/standards/patterns'), { dryRun })
+  }
 }
 
 function main() {

--- a/templates/minimal/AGENTS.md
+++ b/templates/minimal/AGENTS.md
@@ -17,3 +17,14 @@ Quick Commands:
 
 Context Entry:
 - context/INDEX.md
+
+Knowledge Base:
+
+| Directory | Purpose | When to Load |
+|-----------|---------|-------------|
+| context/business/ | Business knowledge | Understanding requirements, domain models |
+| context/tech/ | Technical docs | Architecture, API, conventions |
+| context/experience/ | Experience library | Avoid repeating mistakes |
+| workflow/ | Workflows | Complex task phase guides (optional) |
+| docs/standards/ | Standards | Skill/Command/Agent specs (L1, optional) |
+| docs/standards/patterns/ | Patterns | Phase routing, experience mgmt, context loading (L2, optional) |


### PR DESCRIPTION
## Summary

v1.3.0 新增了 `docs/standards/` 目录，但初始化脚本和部分文档未同步更新。本 PR 补齐这些缺失。

### 模板更新
- AGENTS.md 模板 (x3) 新增 Knowledge Base 导航表，包含 `docs/standards/` 和 `docs/standards/patterns/` 条目

### 脚本更新
- 3 份初始化脚本（`scripts/`、`packages/aief-init/`、`packages/ai-engineering-framework-init/`）在 L1 级别 retrofit 时自动创建 `docs/standards/patterns/` 目录

### 文档更新
- `init/MIGRATION_LEVELS.md` — L2 新增 Skill/Command/Agent 标准规范描述，L3 新增跨切面模式描述
- `README.zh-CN.md` — 同步英文 README：阅读顺序、目录概览、迁移等级、参考资源

### 版本升级
- `@tongsh6/aief-init`: 0.2.0 → 0.3.0
- `@tongsh6/ai-engineering-framework-init`: 0.1.0 → 0.2.0