### PR TITLE
chore: unify npm package versions to match repo tag

### DIFF
--- a/packages/ai-engineering-framework-init/package.json
+++ b/packages/ai-engineering-framework-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tongsh6/ai-engineering-framework-init",
-  "version": "0.2.0",
+  "version": "1.3.1",
   "description": "Optional bootstrap CLI for AI Engineering Framework (AIEF)",
   "license": "MIT",
   "type": "module",

--- a/packages/aief-init/package.json
+++ b/packages/aief-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tongsh6/aief-init",
-  "version": "0.3.0",
+  "version": "1.3.1",
   "description": "Short alias for @tongsh6/ai-engineering-framework-init",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- 将两个 npm 包的版本号统一为 `1.3.1`，与仓库 git tag 保持一致
  - `@tongsh6/aief-init`: `0.3.0` → `1.3.1`
  - `@tongsh6/ai-engineering-framework-init`: `0.2.0` → `1.3.1`
- 后续发布时，仓库 tag 和 npm 包版本号同步递增