### PR TITLE
feat: add CI release workflow and local release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release & Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify version consistency
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: extract
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Tag version: ${TAG_VERSION}"
+
+      - name: Check package versions match tag
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+
+          PKG1_VERSION=$(node -p "require('./packages/aief-init/package.json').version")
+          PKG2_VERSION=$(node -p "require('./packages/ai-engineering-framework-init/package.json').version")
+
+          echo "Tag version:    ${TAG_VERSION}"
+          echo "aief-init:      ${PKG1_VERSION}"
+          echo "ai-eng-fw-init: ${PKG2_VERSION}"
+
+          FAILED=0
+          if [ "${PKG1_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::@tongsh6/aief-init version (${PKG1_VERSION}) does not match tag (${TAG_VERSION})"
+            FAILED=1
+          fi
+          if [ "${PKG2_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::@tongsh6/ai-engineering-framework-init version (${PKG2_VERSION}) does not match tag (${TAG_VERSION})"
+            FAILED=1
+          fi
+          if [ "${FAILED}" -eq 1 ]; then
+            exit 1
+          fi
+          echo "All versions match."
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish @tongsh6/aief-init
+        working-directory: packages/aief-init
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @tongsh6/ai-engineering-framework-init
+        working-directory: packages/ai-engineering-framework-init
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [verify, publish]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          # Find previous tag
+          PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n '2p')
+          if [ -z "${PREV_TAG}" ]; then
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
+          fi
+          echo "Previous tag: ${PREV_TAG}"
+
+          # Generate commit log
+          COMMITS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+          if [ -z "${COMMITS}" ]; then
+            COMMITS="- Version bump and release"
+          fi
+
+          # Write to file for gh release
+          cat > release_notes.md <<NOTES_EOF
+          ## What's Changed
+
+          ${COMMITS}
+
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ github.ref_name }}
+          NOTES_EOF
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes-file release_notes.md

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Release script — synchronises package versions, commits, tags, and pushes.
+ *
+ * Usage:
+ *   node scripts/release.mjs <version>
+ *
+ * Example:
+ *   node scripts/release.mjs 1.4.0
+ *
+ * What it does:
+ *   1. Validates the version format (semver, no "v" prefix)
+ *   2. Ensures you are on the main branch with a clean working tree
+ *   3. Updates both package.json files to the target version
+ *   4. Commits: "release: v<version>"
+ *   5. Tags: v<version>
+ *   6. Pushes commit + tag to origin
+ *
+ * After push, GitHub Actions (.github/workflows/release.yml) will:
+ *   - Verify version consistency
+ *   - npm publish both packages
+ *   - Create a GitHub Release with auto-generated notes
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function run(cmd, opts = {}) {
+  return execSync(cmd, { encoding: 'utf-8', cwd: ROOT, ...opts }).trim()
+}
+
+function fail(msg) {
+  console.error(`\n❌  ${msg}\n`)
+  process.exit(1)
+}
+
+function info(msg) {
+  console.log(`  ✓ ${msg}`)
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const version = process.argv[2]
+if (!version) {
+  fail('Usage: node scripts/release.mjs <version>  (e.g. 1.4.0)')
+}
+
+if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
+  fail(`Invalid semver: "${version}". Use format like 1.4.0 or 2.0.0-beta.1`)
+}
+
+// Must be on main
+const branch = run('git rev-parse --abbrev-ref HEAD')
+if (branch !== 'main') {
+  fail(`Must be on "main" branch (currently on "${branch}").`)
+}
+
+// Working tree must be clean
+const status = run('git status --porcelain')
+if (status) {
+  fail('Working tree is not clean. Commit or stash changes first.')
+}
+
+// Tag must not already exist
+const existingTags = run('git tag --list').split('\n')
+if (existingTags.includes(`v${version}`)) {
+  fail(`Tag v${version} already exists.`)
+}
+
+// ---------------------------------------------------------------------------
+// Update package.json files
+// ---------------------------------------------------------------------------
+
+const PACKAGES = [
+  'packages/aief-init/package.json',
+  'packages/ai-engineering-framework-init/package.json',
+]
+
+console.log(`\nReleasing v${version}\n`)
+
+for (const rel of PACKAGES) {
+  const abs = path.join(ROOT, rel)
+  const pkg = JSON.parse(fs.readFileSync(abs, 'utf-8'))
+  const old = pkg.version
+  pkg.version = version
+  fs.writeFileSync(abs, JSON.stringify(pkg, null, 2) + '\n')
+  info(`${pkg.name}: ${old} → ${version}`)
+}
+
+// ---------------------------------------------------------------------------
+// Git commit, tag, push
+// ---------------------------------------------------------------------------
+
+run(`git add ${PACKAGES.join(' ')}`)
+run(`git commit -m "release: v${version}"`)
+info(`Committed "release: v${version}"`)
+
+run(`git tag v${version} -m "v${version}"`)
+info(`Tagged v${version}`)
+
+run('git push origin main')
+run(`git push origin v${version}`)
+info('Pushed to origin (commit + tag)')
+
+console.log(`
+🎉  Done! GitHub Actions will now:
+    1. Verify version consistency
+    2. Publish to npm
+    3. Create GitHub Release
+
+    Track progress: https://github.com/tongsh6/ai-engineering-framework/actions
+`)


### PR DESCRIPTION
## Summary

添加版本发布的 CI 自动化保障机制，确保仓库 tag 和 npm 包版本号始终一致。

### 新增文件

**`.github/workflows/release.yml`** — GitHub Actions workflow
- 监听 `v*` tag push 触发
- `verify` job: 校验两个 package.json 的版本号与 tag 一致，不一致则失败
- `publish` job: npm publish 两个包
- `release` job: 自动创建 GitHub Release（含 commit log）

**`scripts/release.mjs`** — 本地发布脚本
- 校验：必须在 main 分支、working tree 干净、tag 不存在
- 执行：同步两个 package.json 版本号 → commit → tag → push
- push 后 GitHub Actions 自动接管后续流程

### 发布流程

```bash
# 一条命令完成本地操作
node scripts/release.mjs 1.4.0

# GitHub Actions 自动完成：
# 1. 校验版本一致性（不一致则阻断）
# 2. npm publish 两个包
# 3. 创建 GitHub Release
```

### 前置配置
- `NPM_TOKEN` GitHub Secret ✅ 已配置