### PR TITLE
chore/test: harden release flow and wire canonical checks into CI path

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Build, runtime, and git history remain unaffected.
 - `v1.7.0` - add `validate refs` and `migrate` subcommands
 - `v1.8.0` - make `@tongsh6/aief-init` a thin wrapper delegating to canonical package
 - `v1.8.1` - documentation consistency pass + release/test workflow hardening
+- `v1.9.0` - add `doctor` command for AIEF project health diagnostics
 
 ## Release Verification
 
@@ -437,7 +438,7 @@ Build, runtime, and git history remain unaffected.
 - Automated verifier:
 
 ```bash
-node scripts/post-release-check.mjs 1.8.1
+node scripts/post-release-check.mjs <version>
 ```
 
 ## Roadmap

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -429,6 +429,7 @@ AIEF 是旁路式规范，不会侵入你的业务代码结构。
 - `v1.7.0` - 新增 `validate refs` 与 `migrate` 子命令
 - `v1.8.0` - `@tongsh6/aief-init` 调整为委托 canonical 包的薄包装
 - `v1.8.1` - 文档一致性修复 + 发布/测试流程加固
+- `v1.9.0` - 新增 `doctor` 项目健康诊断命令
 
 ## 发布后校验
 
@@ -436,7 +437,7 @@ AIEF 是旁路式规范，不会侵入你的业务代码结构。
 - 自动校验脚本：
 
 ```bash
-node scripts/post-release-check.mjs 1.8.1
+node scripts/post-release-check.mjs <version>
 ```
 
 ## 规划

--- a/docs/release-post-checklist.md
+++ b/docs/release-post-checklist.md
@@ -5,7 +5,7 @@ Use this checklist immediately after tagging a release to confirm that GitHub an
 ## 1) Run automated checks
 
 ```bash
-node scripts/post-release-check.mjs 1.8.1
+node scripts/post-release-check.mjs <version>
 ```
 
 The script validates:
@@ -19,7 +19,7 @@ The script validates:
 ## 2) Manual spot-check (optional but recommended)
 
 ```bash
-gh release view v1.8.1 --repo tongsh6/ai-engineering-framework
+gh release view v<version> --repo tongsh6/ai-engineering-framework
 gh run list --repo tongsh6/ai-engineering-framework --workflow "Release & Publish" --limit 5
 npm view @tongsh6/aief-init version
 npm view @tongsh6/ai-engineering-framework-init version

--- a/packages/aief-init/test/cli.test.mjs
+++ b/packages/aief-init/test/cli.test.mjs
@@ -8,9 +8,25 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const CLI = path.join(__dirname, '..', 'bin', 'aief-init.mjs')
+const CANONICAL_CLI = path.join(
+  __dirname,
+  '..',
+  '..',
+  'ai-engineering-framework-init',
+  'bin',
+  'aief-init.mjs'
+)
 
 function run(args, opts = {}) {
   return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    cwd: opts.cwd ?? process.cwd(),
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+}
+
+function runCanonical(args, opts = {}) {
+  return spawnSync(process.execPath, [CANONICAL_CLI, ...args], {
     encoding: 'utf8',
     cwd: opts.cwd ?? process.cwd(),
     env: { ...process.env, NO_COLOR: '1' },
@@ -41,6 +57,13 @@ test('no args prints help and exits 0', () => {
   const r = run([])
   assert.equal(r.status, 0)
   assert.match(r.stdout, /aief-init/)
+})
+
+test('canonical --help prints usage and exits 0', () => {
+  const r = runCanonical(['--help'])
+  assert.equal(r.status, 0)
+  assert.match(r.stdout, /aief-init/)
+  assert.match(r.stdout, /doctor/)
 })
 
 // ── Unknown command ───────────────────────────────────────────────────────────
@@ -192,6 +215,18 @@ test('doctor after L0 retrofit exits 0 and warns about missing scripts/aief.mjs'
     assert.match(r2.stdout, /\[PASS\] AGENTS\.md entry file/)
     assert.match(r2.stdout, /\[PASS\] context\/INDEX\.md entry file/)
     assert.match(r2.stdout, /\[WARN\] scripts\/aief\.mjs available/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('canonical doctor on empty directory exits non-zero', () => {
+  const dir = makeTmp()
+  try {
+    const r = runCanonical(['doctor'], { cwd: dir })
+    assert.notEqual(r.status, 0)
+    assert.match(r.stdout, /\[FAIL\] AGENTS\.md entry file/)
+    assert.match(r.stdout, /\[FAIL\] context\/INDEX\.md entry file/)
   } finally {
     cleanup(dir)
   }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -13,6 +13,7 @@
  *   1. Validates the version format (semver, no "v" prefix)
  *   2. Ensures you are on the main branch with a clean working tree
  *   3. Updates both package.json files to the target version
+ *      (and syncs alias dependency to canonical package version)
  *   4. Commits: "release: v<version>"
  *   5. Tags: v<version>
  *   6. Pushes commit + tag to origin
@@ -88,6 +89,9 @@ const PACKAGES = [
   'packages/ai-engineering-framework-init/package.json',
 ]
 
+const ALIAS_PACKAGE = 'packages/aief-init/package.json'
+const CANONICAL_PACKAGE_NAME = '@tongsh6/ai-engineering-framework-init'
+
 console.log(`\nReleasing v${version}\n`)
 
 for (const rel of PACKAGES) {
@@ -97,6 +101,21 @@ for (const rel of PACKAGES) {
   pkg.version = version
   fs.writeFileSync(abs, JSON.stringify(pkg, null, 2) + '\n')
   info(`${pkg.name}: ${old} → ${version}`)
+}
+
+// Keep alias dependency pinned to the same canonical package version.
+{
+  const aliasAbs = path.join(ROOT, ALIAS_PACKAGE)
+  const aliasPkg = JSON.parse(fs.readFileSync(aliasAbs, 'utf-8'))
+  const deps = aliasPkg.dependencies || {}
+  const oldDepVersion = deps[CANONICAL_PACKAGE_NAME]
+  if (oldDepVersion !== version) {
+    aliasPkg.dependencies = { ...deps, [CANONICAL_PACKAGE_NAME]: version }
+    fs.writeFileSync(aliasAbs, JSON.stringify(aliasPkg, null, 2) + '\n')
+    info(
+      `${CANONICAL_PACKAGE_NAME} dependency: ${oldDepVersion || '(unset)'} → ${version}`
+    )
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
1. Harden release automation (`scripts/release.mjs`)
   - keep alias dependency `@tongsh6/ai-engineering-framework-init` in sync with release version
2. Improve post-release docs consistency
   - `docs/release-post-checklist.md` now uses `<version>` placeholders
   - `README.md` / `README.zh-CN.md` include v1.9.0 doctor release note
3. Wire canonical checks into existing CI path without workflow-file change
   - `packages/aief-init/test/cli.test.mjs` now runs canonical CLI checks (`--help`, `doctor`)
   - existing CI step already runs this suite, so canonical checks are now covered

## Verification
- `node --check scripts/release.mjs`
- `node --test packages/aief-init/test/cli.test.mjs` (20/20 pass)
- `node --test packages/ai-engineering-framework-init/test/smoke.test.mjs` (4/4 pass)
- `node scripts/aief.mjs verify` (PASSED)
- `node scripts/post-release-check.mjs 1.9.0` (5/5 pass)