### PR TITLE
feat: add doctor JSON output and base-dir test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Use these commands after initialization/retrofit to keep paths consistent and mi
 # Diagnose AIEF project health (entry files + refs + script availability)
 npx --yes @tongsh6/aief-init@latest doctor
 
+# Machine-readable report for CI/scripts
+npx --yes @tongsh6/aief-init@latest doctor --json
+
 # Validate AIEF path references
 npx --yes @tongsh6/aief-init@latest validate refs
 
@@ -171,6 +174,17 @@ Common flags:
 - `--force`: overwrite existing files (useful when upgrading to `L2`/`L3`)
 - `--base-dir <path>`: generate assets under a single directory
 - `--root-agents`: also write `AGENTS.md` in repo root when `--base-dir` is set
+
+Doctor output example:
+
+```text
+Doctor report for /path/to/project
+[PASS] AGENTS.md entry file
+[PASS] context/INDEX.md entry file
+[WARN] scripts/aief.mjs available
+       hint: Run `aief-init retrofit --level L1` to enable `validate`/`migrate` delegation.
+Summary: pass=2, warn=1, fail=0, blockingFail=0
+```
 
 ### Before / After
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,6 +153,9 @@ npx --yes @tongsh6/aief-init@latest retrofit --level L1 --base-dir AIEF
 # 项目健康诊断（入口文件 + 引用一致性 + 脚本可用性）
 npx --yes @tongsh6/aief-init@latest doctor
 
+# 机器可读输出（便于 CI/脚本）
+npx --yes @tongsh6/aief-init@latest doctor --json
+
 # 校验 AIEF 路径引用
 npx --yes @tongsh6/aief-init@latest validate refs
 
@@ -171,6 +174,17 @@ npx --yes @tongsh6/aief-init@latest migrate --to-base-dir AIEF
 - `--force`：覆盖已存在文件（升级到 `L2`/`L3` 时常用）
 - `--base-dir <path>`：将资产统一输出到单目录
 - `--root-agents`：配合 `--base-dir` 时，同时写入根目录 `AGENTS.md`
+
+Doctor 输出示例：
+
+```text
+Doctor report for /path/to/project
+[PASS] AGENTS.md entry file
+[PASS] context/INDEX.md entry file
+[WARN] scripts/aief.mjs available
+       hint: Run `aief-init retrofit --level L1` to enable `validate`/`migrate` delegation.
+Summary: pass=2, warn=1, fail=0, blockingFail=0
+```
 
 ### Before / After
 

--- a/packages/ai-engineering-framework-init/bin/aief-init.mjs
+++ b/packages/ai-engineering-framework-init/bin/aief-init.mjs
@@ -38,6 +38,7 @@ function printHelp() {
       '  --to-base-dir <path>  Migration target base directory (for migrate)',
       '  --root-agents        Also write AGENTS.md at repo root (useful with --base-dir)',
       '  --no-root-agents     Skip writing AGENTS.md at repo root',
+      '  --json               Print doctor result as JSON (for doctor)',
       '  --fix                Auto-fix deterministic reference issues (for validate refs)',
       '  --force              Overwrite existing files',
       '  --dry-run            Print actions without writing',
@@ -64,6 +65,7 @@ function parseArgs(argv) {
     force: false,
     dryRun: false,
     fix: false,
+    json: false,
     toBaseDir: undefined,
   }
 
@@ -82,6 +84,7 @@ function parseArgs(argv) {
     const a = args[i]
     if (a === '--force') opts.force = true
     else if (a === '--dry-run') opts.dryRun = true
+    else if (a === '--json') opts.json = true
     else if (a === '--fix') opts.fix = true
     else if (a === '--level') {
       const v = args[i + 1]
@@ -132,7 +135,7 @@ function isFile(p) {
   }
 }
 
-function runDoctor({ baseDir }) {
+function runDoctor({ baseDir, json }) {
   const projectRoot = baseDir ? path.resolve(process.cwd(), baseDir) : process.cwd()
   const agentsPath = path.join(projectRoot, 'AGENTS.md')
   const contextIndexPath = path.join(projectRoot, 'context', 'INDEX.md')
@@ -183,20 +186,12 @@ function runDoctor({ baseDir }) {
     })
   }
 
-  process.stdout.write(`Doctor report for ${projectRoot}\n`)
-
   let passCount = 0
   let warnCount = 0
   let failCount = 0
   let blockingFails = 0
 
   for (const item of checks) {
-    const tag =
-      item.level === 'pass' ? '[PASS]' : item.level === 'warn' ? '[WARN]' : '[FAIL]'
-    process.stdout.write(`${tag} ${item.label}\n`)
-    if (item.detail) process.stdout.write(`       ${item.detail}\n`)
-    if (item.hint && item.level !== 'pass') process.stdout.write(`       hint: ${item.hint}\n`)
-
     if (item.level === 'pass') passCount += 1
     else if (item.level === 'warn') warnCount += 1
     else failCount += 1
@@ -204,9 +199,37 @@ function runDoctor({ baseDir }) {
     if (item.level === 'fail' && item.blocking) blockingFails += 1
   }
 
-  process.stdout.write(
-    `Summary: pass=${passCount}, warn=${warnCount}, fail=${failCount}, blockingFail=${blockingFails}\n`
-  )
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          projectRoot,
+          checks,
+          summary: {
+            pass: passCount,
+            warn: warnCount,
+            fail: failCount,
+            blockingFail: blockingFails,
+          },
+        },
+        null,
+        2
+      )}\n`
+    )
+  } else {
+    process.stdout.write(`Doctor report for ${projectRoot}\n`)
+    for (const item of checks) {
+      const tag =
+        item.level === 'pass' ? '[PASS]' : item.level === 'warn' ? '[WARN]' : '[FAIL]'
+      process.stdout.write(`${tag} ${item.label}\n`)
+      if (item.detail) process.stdout.write(`       ${item.detail}\n`)
+      if (item.hint && item.level !== 'pass') process.stdout.write(`       hint: ${item.hint}\n`)
+    }
+
+    process.stdout.write(
+      `Summary: pass=${passCount}, warn=${warnCount}, fail=${failCount}, blockingFail=${blockingFails}\n`
+    )
+  }
 
   if (blockingFails > 0) {
     process.exit(1)
@@ -1158,7 +1181,7 @@ function main() {
     }
 
     if (opts.command === 'doctor') {
-      runDoctor({ baseDir })
+      runDoctor({ baseDir, json: opts.json })
       return
     }
 

--- a/packages/ai-engineering-framework-init/test/smoke.test.mjs
+++ b/packages/ai-engineering-framework-init/test/smoke.test.mjs
@@ -66,3 +66,17 @@ test('canonical CLI doctor reports missing entry files on empty directory', () =
     cleanup(dir)
   }
 })
+
+test('canonical CLI doctor --json returns machine-readable summary', () => {
+  const dir = makeTmp()
+  try {
+    const r = run(['doctor', '--json'], { cwd: dir })
+    assert.notEqual(r.status, 0)
+    const payload = JSON.parse(r.stdout)
+    assert.equal(payload.summary.fail, 2)
+    assert.equal(payload.summary.warn, 1)
+    assert.equal(payload.summary.blockingFail, 2)
+  } finally {
+    cleanup(dir)
+  }
+})

--- a/packages/aief-init/test/cli.test.mjs
+++ b/packages/aief-init/test/cli.test.mjs
@@ -204,6 +204,21 @@ test('doctor on empty directory exits non-zero with actionable hints', () => {
   }
 })
 
+test('doctor --json returns structured report on empty directory', () => {
+  const dir = makeTmp()
+  try {
+    const r = run(['doctor', '--json'], { cwd: dir })
+    assert.notEqual(r.status, 0)
+    const payload = JSON.parse(r.stdout)
+    assert.equal(typeof payload.projectRoot, 'string')
+    assert.equal(payload.summary.fail, 2)
+    assert.equal(payload.summary.warn, 1)
+    assert.equal(payload.summary.blockingFail, 2)
+  } finally {
+    cleanup(dir)
+  }
+})
+
 test('doctor after L0 retrofit exits 0 and warns about missing scripts/aief.mjs', () => {
   const dir = makeTmp()
   try {
@@ -211,6 +226,22 @@ test('doctor after L0 retrofit exits 0 and warns about missing scripts/aief.mjs'
     assert.equal(r1.status, 0, `stderr: ${r1.stderr}`)
 
     const r2 = run(['doctor'], { cwd: dir })
+    assert.equal(r2.status, 0, `stdout: ${r2.stdout}\nstderr: ${r2.stderr}`)
+    assert.match(r2.stdout, /\[PASS\] AGENTS\.md entry file/)
+    assert.match(r2.stdout, /\[PASS\] context\/INDEX\.md entry file/)
+    assert.match(r2.stdout, /\[WARN\] scripts\/aief\.mjs available/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('doctor --base-dir checks scoped AIEF directory', () => {
+  const dir = makeTmp()
+  try {
+    const r1 = run(['retrofit', '--level', 'L0', '--base-dir', 'AIEF', '--locale', 'en'], { cwd: dir })
+    assert.equal(r1.status, 0, `stderr: ${r1.stderr}`)
+
+    const r2 = run(['doctor', '--base-dir', 'AIEF'], { cwd: dir })
     assert.equal(r2.status, 0, `stdout: ${r2.stdout}\nstderr: ${r2.stderr}`)
     assert.match(r2.stdout, /\[PASS\] AGENTS\.md entry file/)
     assert.match(r2.stdout, /\[PASS\] context\/INDEX\.md entry file/)


### PR DESCRIPTION
## Summary
- add `--json` option for `aief-init doctor` (machine-readable diagnostics)
- keep existing human-readable output unchanged for default doctor mode
- expand doctor coverage:
  - alias integration tests now cover `doctor --json` and `doctor --base-dir`
  - canonical smoke tests now cover `doctor --json`
- update README / README.zh-CN with doctor JSON usage and sample output

## Verification
- `node --check packages/ai-engineering-framework-init/bin/aief-init.mjs`
- `node --test packages/aief-init/test/cli.test.mjs` (22/22 pass)
- `node --test packages/ai-engineering-framework-init/test/smoke.test.mjs` (5/5 pass)
- `node scripts/aief.mjs verify` (PASSED)